### PR TITLE
Add gfx1150 to legacy CK supported hardware whitelist

### DIFF
--- a/src/include/miopen/solver/legacy_ck_common.hpp
+++ b/src/include/miopen/solver/legacy_ck_common.hpp
@@ -55,6 +55,7 @@ static inline bool is_ck_supported_hardware(const Handle& handle)
            StartsWith(handle.GetDeviceName(), "gfx1100") ||
            StartsWith(handle.GetDeviceName(), "gfx1101") ||
            StartsWith(handle.GetDeviceName(), "gfx1102") ||
+           StartsWith(handle.GetDeviceName(), "gfx1150") ||
            StartsWith(handle.GetDeviceName(), "gfx1200") ||
            StartsWith(handle.GetDeviceName(), "gfx1201");
 }


### PR DESCRIPTION
## Summary
- Adds `gfx1150` (Ryzen AI 300 / Strix Point, RDNA 3.5) to `is_ck_supported_hardware()` in `legacy_ck_common.hpp`
- Without this, MIOpen skips all legacy CK solvers on gfx1150, falling back to only `ConvDirectNaiveConvFwd` and `GemmFwd`
- gfx1150 is the same ISA family as gfx1100/gfx1101/gfx1102 which are already whitelisted

## Test plan
- Tested on AMD Ryzen AI 9 HX 370 (Radeon 890M / gfx1150) with ROCm 7.2.0
- Legacy CK convolution solvers load and run correctly with this patch
- One-line change, no risk to existing targets

## Refs
- ROCm/MIOpen#3860 (convolution with miopenHalf fails on gfx1150)
- ROCm/rocm-libraries#6045 (full three-bug analysis for gfx1150)

🤖 Generated with [Claude Code](https://claude.com/claude-code)